### PR TITLE
Change the argument of silk_HP_variable_cutoff() to a pointer.

### DIFF
--- a/src/opus-1.3.1/silk/HP_variable_cutoff.c
+++ b/src/opus-1.3.1/silk/HP_variable_cutoff.c
@@ -37,7 +37,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 /* High-pass filter with cutoff frequency adaptation based on pitch lag statistics */
 void silk_HP_variable_cutoff(
-    silk_encoder_state_Fxx          state_Fxx[]                         /* I/O  Encoder states                              */
+    silk_encoder_state_Fxx          *state_Fxx                           /* I/O  Encoder states                              */
 )
 {
    opus_int   quality_Q15;

--- a/src/opus-1.3.1/silk/float/main_FLP.h
+++ b/src/opus-1.3.1/silk/float/main_FLP.h
@@ -51,7 +51,7 @@ extern "C"
 
 /* High-pass filter with cutoff frequency adaptation based on pitch lag statistics */
 void silk_HP_variable_cutoff(
-    silk_encoder_state_Fxx          state_Fxx[]                         /* I/O  Encoder states                              */
+    silk_encoder_state_Fxx         *state_Fxx                           /* I/O  Encoder states                              */
 );
 
 /* Encoder main function */


### PR DESCRIPTION
Change the argument of silk_HP_variable_cutoff() to a pointer to suppress warnings due to type differences when building in Arduino IDE.